### PR TITLE
Make Docker image smaller, simplify actor run script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .git/
+.github/
 .vscode/
 screenshot/
 tests/
+images/
 *.txt
+*.md
 !/requirements.txt
 venv/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,32 @@
+# We need the non-slim image for the apify-cli installation
 FROM nikolaik/python-nodejs:python3.7-nodejs16 as build
-WORKDIR /wheels
-COPY requirements.txt /opt/sherlock/
-RUN pip3 wheel -r /opt/sherlock/requirements.txt
 
+# Install the Apify CLI globally, to /usr/lib/node_modules
+RUN npm install -g apify-cli@0.7.1-beta.4
 
-FROM nikolaik/python-nodejs:python3.7-nodejs16
-RUN apt-get update && apt-get install jq -y
+# To save space, we can use the slim image for running
+FROM nikolaik/python-nodejs:python3.7-nodejs16-slim as run
 WORKDIR /opt/sherlock
-ARG VCS_REF
-ARG VCS_URL="https://github.com/sherlock-project/sherlock"
-LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url=$VCS_URL
-COPY --from=build /wheels /wheels
-COPY . /opt/sherlock/
-RUN pip3 install -r requirements.txt -f /wheels \
-  && rm -rf /wheels \
-  && rm -rf /root/.cache/pip/*
-RUN npm install -g apify-cli@0.7.1-beta.2
 
+# Copy over the global node_modules from the build stage
+COPY --from=build /usr/lib/node_modules /usr/lib/node_modules
+
+# Add symlink to be able to run `apify` globally
+RUN ln -s /usr/lib/node_modules/apify-cli/src/bin/run /usr/bin/apify
+
+# Install jq and miller for JSON and CSV processing
+RUN apt-get update \
+ && apt-get install -y \
+        jq \
+        miller \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the Python requirements
+COPY requirements.txt .
+RUN pip3 install --no-cache -r requirements.txt
+
+# Copy over the rest of the code
+COPY . .
+
+# Run the actor code by default
 CMD ./.actor/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM nikolaik/python-nodejs:python3.7-nodejs16 as build
 
 # Install the Apify CLI globally, to /usr/lib/node_modules
-RUN npm install -g apify-cli@0.7.1-beta.4
+RUN npm install -g apify-cli
 
 # To save space, we can use the slim image for running
 FROM nikolaik/python-nodejs:python3.7-nodejs16-slim as run


### PR DESCRIPTION
Some small improvements:
- I made the resulting Docker image smaller by:
	- using a `-slim` image for the last stage (which needs some changes to the multistage build)
	- cleaning the `apt` cache after `apt-get install`
	- adding some unnecessary stuff to `.dockerignore`
- I also simplified the `Dockerfile` by getting rid of the Python wheel magic and exchanging it with `pip3 install --no-cache`, which achieves the same result
- I simplified the actor shell script by:
	- removing the unnecessary reading of input to an array
	- using [Miller](https://github.com/johnkerl/miller) to transform the results from CSV to JSON